### PR TITLE
Extending name filter to allow for multiple identifier checks

### DIFF
--- a/AgileSqlClub.SqlPackageFilter.UnitTests/AgileSqlClub.SqlPackageFilter.UnitTests.csproj
+++ b/AgileSqlClub.SqlPackageFilter.UnitTests/AgileSqlClub.SqlPackageFilter.UnitTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Config\FilterArgsTests.cs" />
     <Compile Include="Config\TestDisplayMessageHandler.cs" />
     <Compile Include="Config\XmlFilterParserTests.cs" />
+    <Compile Include="Optional\OptionalTests.cs" />
     <Compile Include="Rule\ObjectIdentifierFactoryTests.cs" />
     <Compile Include="Rule\KeeperDeciderTests.cs" />
     <Compile Include="Rule\NamedObjectMatchTests.cs" />

--- a/AgileSqlClub.SqlPackageFilter.UnitTests/Optional/OptionalTests.cs
+++ b/AgileSqlClub.SqlPackageFilter.UnitTests/Optional/OptionalTests.cs
@@ -1,0 +1,102 @@
+﻿using AgileSqlClub.SqlPackageFilter.Extensions;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace AgileSqlClub.SqlPackageFilter.UnitTests.Optional
+{
+    [TestFixture]
+    public class OptionalTests
+    {
+        class MyObject2 : MyObject
+        {
+            public string MyValue { get; set; }
+            public int MyNumber { get; set; }
+        }
+
+        class MyObject
+        {
+            public MyObject[] MyObjects { get; set; }
+        }
+
+        [Test]
+        public void Optional_Nested_Value_In_Array_Should_Be_My_Value()
+        {
+            var myobject = new MyObject2
+            {
+                MyValue = "my value"
+            };
+
+            var myObjects = new MyObject
+            {
+                MyObjects = new MyObject[] { myobject }
+            };
+
+            var valueFromTest = String.Empty;
+            var value =
+                new Optional<MyObject>(myObjects)
+                .ValueOrDefault(o => o?.MyObjects?.ToList())
+                .OptionalAt(0).ValueOrDefault(o => o as MyObject2)
+                .ValueOrDefault(o => o?.MyValue)
+                .Default(() => "empty")
+                .Evaluate();
+
+            Assert.AreEqual("my value", value);
+        }
+
+        [Test]
+        public void Optional_Nested_Value_In_Array_Should_Be_Empty()
+        {
+            var myobject = new MyObject2
+            {
+                MyValue = "my value"
+            };
+
+            var myObjects = new MyObject
+            {
+                MyObjects = new MyObject[] { } //empty array
+            };
+
+            var value =
+                new Optional<MyObject>(myObjects)
+                .ValueOrDefault(o => o?.MyObjects?.ToList())
+                .OptionalAt(0).ValueOrDefault(o => o as MyObject2)
+                .ValueOrDefault(o => o?.MyValue)
+                .Default(() => "empty")
+                .Evaluate();
+
+            Assert.AreEqual("empty", value);
+        }
+
+        [Test]
+        public void Optional_Empty_Object_Should_Be_Empty()
+        {
+            MyObject myObjects = null;
+
+            var value =
+                new Optional<MyObject>(myObjects)
+                .ValueOrDefault(o => o?.MyObjects?.ToList())
+                .OptionalAt(0).ValueOrDefault(o => o as MyObject2)
+                .ValueOrDefault(o => o?.MyValue)
+                .Default(() => "empty")
+                .Evaluate();
+
+            Assert.AreEqual("empty", value);
+        }
+
+        [Test]
+        public void Optional_Empty_Object_Should_Be_Null()
+        {
+            MyObject myObjects = null;
+
+            var value =
+                new Optional<MyObject>(myObjects)
+                .ValueOrDefault(o => o?.MyObjects?.ToList())
+                .OptionalAt(0).ValueOrDefault(o => o as MyObject2)
+                .ValueOrDefault(o => o?.MyValue)
+                .Evaluate();
+
+            Assert.AreEqual(null, value);
+        }
+    }
+}

--- a/SqlPackageFilter/AgileSqlClub.SqlPackageFilter.csproj
+++ b/SqlPackageFilter/AgileSqlClub.SqlPackageFilter.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Filter\MatchType.cs" />
     <Compile Include="Config\FilterOperation.cs" />
     <Compile Include="Filter\ObjectIdentifierFactory.cs" />
+    <Compile Include="Extensions\OptionalExtensions.cs" />
     <Compile Include="Rules\FilterRule.cs" />
     <Compile Include="Filter\FilterType.cs" />
     <Compile Include="Rules\NamedObjectFilterRule.cs" />

--- a/SqlPackageFilter/AgileSqlClub.SqlPackageFilter.csproj
+++ b/SqlPackageFilter/AgileSqlClub.SqlPackageFilter.csproj
@@ -121,6 +121,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y "$(TargetPath)" "C:\Program Files\Microsoft SQL Server\130\DAC\bin"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SqlPackageFilter/Extensions/OptionalExtensions.cs
+++ b/SqlPackageFilter/Extensions/OptionalExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AgileSqlClub.SqlPackageFilter.Extensions
+{
+    public class Optional<T> where T : class
+    {
+        internal readonly T instance = default(T);
+        private Func<T> getDefault = null;
+
+        public Optional(T instance, Func<T> getDefault = null)
+        {
+            this.instance = instance;
+            this.getDefault = getDefault;
+        }
+
+        public Optional<T> Default(Func<T> func)
+        {
+            this.getDefault = func;
+            return this;
+        }
+
+        public T Evaluate()
+        {
+            if (this.instance != default(T))
+                return this.instance;
+            else if (this.getDefault != null)
+                return this.getDefault();
+            return default(T);
+        }
+    }
+
+    public static class OptionalExtensions
+    {
+        public static Optional<T> AsOptional<T>(this T obj) where T : class
+        {
+            return new Optional<T>(obj);
+        }
+
+        public static Optional<T> AsOptional<T>(this object obj, Func<object, T> func) where T : class
+        {
+            var value = func.Invoke(obj);
+            return new Optional<T>(value);
+        }
+
+        public static Optional<T2> ValueOrDefault<T1, T2>(this Optional<T1> optional, Func<T1, T2> func) where T1 : class where T2 : class
+        {
+            var value = func.Invoke(optional.instance);
+            return new Optional<T2>(value);
+        }
+
+        public static Optional<T> OptionalAt<T>(this Optional<IList<T>> optional, int index = 0) where T : class
+        {
+            return new Optional<T>(optional?.instance?.ElementAtOrDefault(index));
+        }
+
+        public static Optional<T> OptionalAt<T>(this Optional<List<T>> optional, int index = 0) where T : class
+        {
+            return new Optional<T>(optional?.instance?.ElementAtOrDefault(index));
+        }
+    }
+}

--- a/SqlPackageFilter/Filter/DeploymentFilter.cs
+++ b/SqlPackageFilter/Filter/DeploymentFilter.cs
@@ -1,74 +1,78 @@
 ﻿using System;
+using System.Linq;
 using System.Diagnostics;
 using AgileSqlClub.SqlPackageFilter.Config;
 using AgileSqlClub.SqlPackageFilter.Rules;
 using Microsoft.SqlServer.Dac.Deployment;
 using Microsoft.SqlServer.Dac.Extensibility;
+using System.Text;
 
 namespace AgileSqlClub.SqlPackageFilter.Filter
 {
-  [ExportDeploymentPlanModifier("AgileSqlClub.DeploymentFilterContributor", "1.4.3.0")]
-  public class DeploymentFilter : DeploymentPlanModifier, IDisplayMessageHandler
-  {
-    private DisplayMessageLevel _displayLevel = DisplayMessageLevel.Errors;
-
-    public void ShowMessage(string message, DisplayMessageLevel level)
+    [ExportDeploymentPlanModifier("AgileSqlClub.DeploymentFilterContributor", "1.4.3.0")]
+    public class DeploymentFilter : DeploymentPlanModifier, IDisplayMessageHandler
     {
-      if (_displayLevel >= level)
-        ShowMessage(message);
-    }
+        private DisplayMessageLevel _displayLevel = DisplayMessageLevel.Errors;
 
-    public void SetMessageLevel(DisplayMessageLevel level)
-    {
-      _displayLevel = level;
-    }
-
-    public void ShowMessage(string message)
-    {
-      PublishMessage(new ExtensibilityError(message, Severity.Message));
-    }
-
-    protected override void OnExecute(DeploymentPlanContributorContext context)
-    {
-      
-      try
-      {
-        PublishMessage(new ExtensibilityError("Starting AgileSqlClub.DeploymentFilterContributor", Severity.Message));
-
-        var rules = new RuleDefinitionFactory(this).BuildRules(context.Arguments, this);
-
-        var decider = new KeeperDecider(rules);
-
-        var next = context.PlanHandle.Head;
-
-        while (next != null)
+        public void ShowMessage(string message, DisplayMessageLevel level)
         {
-
-          var current = next;
-          next = current.Next;
-
-          var stepDecider = DeploymentStepDecider.Decide(current, decider);
-
-          if (stepDecider != null)
-          {
-            if (stepDecider.Remove)
-            {
-              Remove(context.PlanHandle, current);
-              PublishMessage(new ExtensibilityError($"Step removed from deployment by SqlPackageFilter, object: {stepDecider.ObjectName}, step type: {stepDecider.StepType}", Severity.Message));
-            }
-            else if (_displayLevel == DisplayMessageLevel.Info)
-              PublishMessage(new ExtensibilityError($"Step has not been removed from deployment, object: {stepDecider.ObjectName} type: {stepDecider.StepType}", Severity.Message));
-
-          }
+            if (_displayLevel >= level)
+                ShowMessage(message);
         }
 
-        PublishMessage(new ExtensibilityError("Completed AgileSqlClub.DeploymentFilterContributor", Severity.Message));
-      }
-      catch (Exception e)
-      {
-        //global exception as we don't want to break sqlpackage.exe
-        PublishMessage(new ExtensibilityError($"Error in DeploymentFilter: {e.Message}\r\nStack: {e.StackTrace}", Severity.Error));
-      }
+        public void SetMessageLevel(DisplayMessageLevel level)
+        {
+            _displayLevel = level;
+        }
+
+        public void ShowMessage(string message)
+        {
+            PublishMessage(new ExtensibilityError(message, Severity.Message));
+        }
+
+        protected override void OnExecute(DeploymentPlanContributorContext context)
+        {
+
+            try
+            {
+                PublishMessage(new ExtensibilityError("Starting AgileSqlClub.DeploymentFilterContributor", Severity.Message));
+
+                var rules = new RuleDefinitionFactory(this).BuildRules(context.Arguments, this);
+
+                var decider = new KeeperDecider(rules);
+
+                var next = context.PlanHandle.Head;
+
+                while (next != null)
+                {
+
+                    var current = next;
+                    next = current.Next;
+
+                    var stepDecider = DeploymentStepDecider.Decide(current, decider);
+
+                    if (stepDecider != null)
+                    {
+                        if (stepDecider.Remove)
+                        {
+                            Remove(context.PlanHandle, current);
+
+                            PublishMessage(new ExtensibilityError($"Step removed from deployment by SqlPackageFilter, object: {String.Join(", ", stepDecider.ObjectNames)}, step type: {stepDecider.StepType}", Severity.Message));
+
+                        }
+                        else if (_displayLevel == DisplayMessageLevel.Info)
+                            PublishMessage(new ExtensibilityError($"Step has not been removed from deployment, object: {String.Join(", ", stepDecider.ObjectNames)}, step type: {stepDecider.StepType}", Severity.Message));
+
+                    }
+                }
+
+                PublishMessage(new ExtensibilityError("Completed AgileSqlClub.DeploymentFilterContributor", Severity.Message));
+            }
+            catch (Exception e)
+            {
+                //global exception as we don't want to break sqlpackage.exe
+                PublishMessage(new ExtensibilityError($"Error in DeploymentFilter: {e.Message}\r\nStack: {e.StackTrace}", Severity.Error));
+            }
+        }
     }
-  }
 }

--- a/SqlPackageFilter/Filter/DeploymentStepDecider.cs
+++ b/SqlPackageFilter/Filter/DeploymentStepDecider.cs
@@ -1,60 +1,158 @@
 using AgileSqlClub.SqlPackageFilter.Rules;
+using AgileSqlClub.SqlPackageFilter.Extensions;
 using Microsoft.SqlServer.Dac.Deployment;
 using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AgileSqlClub.SqlPackageFilter.Filter
 {
-  public static class DeploymentStepDecider
-  {
-    public static DeploymentStepDecision Decide(DeploymentStep step, KeeperDecider decider)
+    public static class DeploymentStepDecider
     {
-      return RemoveCreateElement(step, decider) ?? RemoveDropStep(step, decider) ?? RemoveAlterStep(step, decider) ?? RemoveDataLossCheckStep(step, decider);
+        public static DeploymentStepDecision Decide(DeploymentStep step, KeeperDecider decider)
+        {
+            return RemoveCreateElement(step, decider) ?? RemoveDropStep(step, decider) ?? RemoveAlterStep(step, decider) ?? RemoveDataLossCheckStep(step, decider);
+        }
+
+        private static DeploymentStepDecision RemoveDataLossCheckStep(DeploymentStep step, KeeperDecider decider)
+        {
+            var dlcStep = new DataLossCheckStep(step);
+
+            if (dlcStep == null || !dlcStep.IsDataLossCheck)
+                return null;
+
+            var objectNames = GetAllIdentifiersFromStep(step);
+
+            return new DeploymentStepDecision()
+            {
+                Remove = decider.ShouldRemoveFromPlan(new ObjectIdentifier(objectNames), ModelSchema.Table, StepType.Drop),
+                StepType = StepType.DataLossCheck,
+                ObjectNames = objectNames
+            };
+        }
+
+        private static DeploymentStepDecision RemoveAlterStep(DeploymentStep step, KeeperDecider decider)
+        {
+            var alterStep = step as AlterElementStep;
+
+            if (alterStep == null)
+                return null;
+
+            var objectNames = GetAllIdentifiersFromStep(step);
+
+            return new DeploymentStepDecision()
+            {
+                Remove = decider.ShouldRemoveFromPlan(new ObjectIdentifier(objectNames), alterStep.TargetElement?.ObjectType, StepType.Alter, alterStep),
+                StepType = StepType.Alter,
+                ObjectNames = GetAllIdentifiersFromStep(step)
+            };
+        }
+
+        private static DeploymentStepDecision RemoveDropStep(DeploymentStep step, KeeperDecider decider)
+        {
+            var dropStep = step as DropElementStep;
+
+            if (dropStep == null)
+                return null;
+
+            var objectNames = GetAllIdentifiersFromStep(step);
+
+            return new DeploymentStepDecision()
+            {
+                Remove = decider.ShouldRemoveFromPlan(new ObjectIdentifier(objectNames), dropStep.TargetElement?.ObjectType, StepType.Drop),
+                StepType = StepType.Drop,
+                ObjectNames = objectNames
+            };
+        }
+
+        private static DeploymentStepDecision RemoveCreateElement(DeploymentStep step, KeeperDecider decider)
+        {
+            var createStep = step as CreateElementStep;
+
+            if (createStep == null)
+                return null;
+
+            var objectNames = GetAllIdentifiersFromStep(step);
+
+            return new DeploymentStepDecision()
+            {
+                Remove = decider.ShouldRemoveFromPlan(new ObjectIdentifier(objectNames), createStep.SourceElement?.ObjectType, StepType.Create),
+                StepType = StepType.Create,
+                ObjectNames = objectNames
+            };
+        }
+
+        private static Optional<string> GetColumnFromAlterTableStatement(TSqlStatement statement)
+        {
+            return statement
+                .AsOptional(s => s as AlterTableAddTableElementStatement)
+                .ValueOrDefault(ats => ats?.Definition?.TableConstraints)
+                .OptionalAt(0).ValueOrDefault(tc => tc as UniqueConstraintDefinition)
+                .ValueOrDefault(ucd => ucd?.Columns)
+                .OptionalAt(0).ValueOrDefault(c => c?.Column?.MultiPartIdentifier?.Identifiers)
+                .OptionalAt(0).ValueOrDefault(i => i?.Value);
+        }
+
+        private static Optional<string> GetTableTokensFromAlterTableStatement(TSqlStatement statement)
+        {
+            var returnValue = String.Empty;
+
+            var optional = statement
+                .AsOptional(s => s as AlterTableAddTableElementStatement)
+                .ValueOrDefault(ats => ats?.SchemaObjectName?.Identifiers?.Select(i => i.Value))
+                .Default(() => new List<String>())
+                .Evaluate();
+
+            return String.Join(".", optional).AsOptional();
+        }
+
+        private static string[] GetAllIdentifiersFromStep(DeploymentStep sourceStep)
+        {
+            var tokens = new List<string>();
+
+            if (sourceStep is CreateElementStep)
+            {
+                var step = sourceStep as CreateElementStep;
+
+                var statement = step.Script
+                    .AsOptional(s => s as TSqlScript)
+                    .ValueOrDefault(s => s?.Batches)
+                    .OptionalAt(0).ValueOrDefault(b => b?.Statements)
+                    .OptionalAt(0);
+
+                var column = GetColumnFromAlterTableStatement(statement.Evaluate());
+                var tableTokens = GetTableTokensFromAlterTableStatement(statement.Evaluate());
+
+                tokens.Add(step.SourceElement?.Name?.ToString() ?? "");
+                tokens.Add(column.Evaluate());
+                tokens.Add(tableTokens.Evaluate());
+            }
+            else if (sourceStep is DropElementStep)
+            {
+                var step = sourceStep as DropElementStep;
+                //todo optional stuff
+                tokens.Add(step.TargetElement?.Name?.ToString() ?? "");
+
+            }
+            else if (sourceStep is AlterElementStep)
+            {
+                var step = sourceStep as AlterElementStep;
+                //todo optional stuff
+                tokens.Add(step.TargetElement?.Name?.ToString() ?? "");
+            }
+            else
+            {
+                var step = new DataLossCheckStep(sourceStep);
+                if (step != null && step.IsDataLossCheck)
+                {
+                    //todo optional stuff
+                    tokens.Add(step.ObjectName.ToString());
+                }
+            }
+
+            return tokens.ToArray();
+        }
     }
-
-    private static DeploymentStepDecision RemoveDataLossCheckStep(DeploymentStep step, KeeperDecider decider)
-    {
-      var dlcStep = new DataLossCheckStep(step);
-      return !dlcStep.IsDataLossCheck ? null : new DeploymentStepDecision() {
-        Remove = decider.ShouldRemoveFromPlan(dlcStep.ObjectName, ModelSchema.Table, StepType.Drop),
-        StepType = StepType.DataLossCheck,
-        ObjectName = dlcStep.ObjectName.ToString()
-      };
-    }
-
-    private static DeploymentStepDecision RemoveAlterStep(DeploymentStep step, KeeperDecider decider)
-    {
-      var alterStep = step as AlterElementStep;
-
-      return alterStep == null ? null : new DeploymentStepDecision()
-      {
-        Remove = decider.ShouldRemoveFromPlan(alterStep.TargetElement?.Name ?? new ObjectIdentifier(), alterStep.TargetElement?.ObjectType, StepType.Alter, alterStep),
-        StepType = StepType.Alter,
-        ObjectName = alterStep.TargetElement?.Name?.ToString() ?? ""
-      };
-    }
-
-    private static DeploymentStepDecision RemoveDropStep(DeploymentStep step, KeeperDecider decider)
-    {
-      var dropStep = step as DropElementStep;
-
-      return dropStep == null ? null : new DeploymentStepDecision()
-      {
-        Remove = decider.ShouldRemoveFromPlan(dropStep.TargetElement?.Name ?? new ObjectIdentifier(), dropStep.TargetElement?.ObjectType, StepType.Drop),
-        StepType = StepType.Drop,
-        ObjectName = dropStep.TargetElement?.Name?.ToString() ?? ""
-      };
-    }
-
-    private static DeploymentStepDecision RemoveCreateElement(DeploymentStep step, KeeperDecider decider)
-    {
-      var createStep = step as CreateElementStep;
-
-      return createStep == null ? null : new DeploymentStepDecision()
-      {
-        Remove = decider.ShouldRemoveFromPlan(createStep.SourceElement?.Name ?? new ObjectIdentifier(), createStep.SourceElement?.ObjectType, StepType.Create),
-        StepType = StepType.Create,
-        ObjectName = createStep.SourceElement?.Name?.ToString() ?? ""
-      };
-    }
-  }
 }

--- a/SqlPackageFilter/Filter/DeploymentStepDecision.cs
+++ b/SqlPackageFilter/Filter/DeploymentStepDecision.cs
@@ -1,9 +1,10 @@
 ﻿namespace AgileSqlClub.SqlPackageFilter.Filter
 {
-  public class DeploymentStepDecision
-  {
-    public bool Remove { get; set; }
-    public StepType StepType { get; set; }
-    public string ObjectName { get; set; }
-  }
+    public class DeploymentStepDecision
+    {
+        public bool Remove { get; set; }
+        public StepType StepType { get; set; }
+        //public string ObjectName { get; set; }
+        public string[] ObjectNames { get; set; }
+    }
 }

--- a/SqlPackageFilter/Rules/NamedObjectFilterRule.cs
+++ b/SqlPackageFilter/Rules/NamedObjectFilterRule.cs
@@ -16,9 +16,11 @@ namespace AgileSqlClub.SqlPackageFilter.Rules
 
         public override bool Matches(ObjectIdentifier name, ModelTypeClass type, DeploymentStep step = null)
         {
-            var objectName = name.Parts.LastOrDefault();
-            
-            return !String.IsNullOrEmpty(objectName) && (Matches(objectName));
+            foreach (var part in name.Parts)
+                if (!String.IsNullOrEmpty(part) && (Matches(part)))
+                    return true;
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
I wanted to use this extension, but I found it to be rather limiting.
It did not found anonymous constraints, so I extended the filter to gather information from not only the name of the object, but also from the table and columns affected by the deployment step.

This was implemented for a create deployment step, but needs to be extended for the other ones.

Also, all of the unit tests are green, I did not get the integration tests to work because I don't have the database locally.

Kr,
Maarten