### PR TITLE
MultiPartName filter type

### DIFF
--- a/AgileSqlClub.SqlPackageFilter.UnitTests/AgileSqlClub.SqlPackageFilter.UnitTests.csproj
+++ b/AgileSqlClub.SqlPackageFilter.UnitTests/AgileSqlClub.SqlPackageFilter.UnitTests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Config\FilterArgsTests.cs" />
     <Compile Include="Config\TestDisplayMessageHandler.cs" />
     <Compile Include="Config\XmlFilterParserTests.cs" />
+    <Compile Include="Rule\MultiPartNamedObjectMatchTests.cs" />
     <Compile Include="Rule\ObjectIdentifierFactoryTests.cs" />
     <Compile Include="Rule\KeeperDeciderTests.cs" />
     <Compile Include="Rule\NamedObjectMatchTests.cs" />

--- a/AgileSqlClub.SqlPackageFilter.UnitTests/Config/FilterArgsTests.cs
+++ b/AgileSqlClub.SqlPackageFilter.UnitTests/Config/FilterArgsTests.cs
@@ -67,6 +67,24 @@ namespace AgileSqlClub.SqlPackageFilter.UnitTests.Config
         }
 
         [Test]
+        public void Parses_MultiPartName_Type()
+        {
+            var parser = new CommandLineFilterParser(_handler);
+            var definition = parser.GetDefinitions("KeepMultiPartName([a-zA-Z]99.*)");
+
+            Assert.AreEqual(FilterType.MultiPartName, definition.FilterType);
+        }
+
+        [Test]
+        public void Parses_Name_As_MultiPartName_Type()
+        {
+            var parser = new CommandLineFilterParser(_handler);
+            var definition = parser.GetDefinitions("KeepName(dev,Table.*)");
+
+            Assert.AreEqual(FilterType.MultiPartName, definition.FilterType);
+        }
+
+        [Test]
         public void Parses_Match()
         {
             var parser = new CommandLineFilterParser(_handler);

--- a/AgileSqlClub.SqlPackageFilter.UnitTests/Rule/MultiPartNamedObjectMatchTests.cs
+++ b/AgileSqlClub.SqlPackageFilter.UnitTests/Rule/MultiPartNamedObjectMatchTests.cs
@@ -1,0 +1,110 @@
+using AgileSqlClub.SqlPackageFilter.Filter;
+using AgileSqlClub.SqlPackageFilter.Rules;
+using Microsoft.SqlServer.Dac.Model;
+using NUnit.Framework;
+
+namespace AgileSqlClub.SqlPackageFilter.UnitTests.Rule
+{
+    [TestFixture]
+    public class MultiPartNamedObjectMatchTests
+    {
+        [Test]
+        public void Matches_Name_That_Matches_Regex()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "[a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Matches_Name_That_Matches_Regex_For_Right_To_Left()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "[a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("dbo", "Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Does_Not_Match_Name_That_Does_Not_Match_Regex()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "^[0-9][a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("WOWSES9898989Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Does_Not_Match_Name_That_Does_Not_Match_Regex_For_Right_To_Left()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "^[0-9][a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("Tab", "WOWSES9898989Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Does_Match_Name_That_Does_Not_Match_Regex_But_Is_A_Negative_Match_Type()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, ".*blah.*", MatchType.DoesNotMatch);
+            var objectName = new ObjectIdentifier("WOWSES9898989Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Matches_MultiPart_Name_That_Matches_Regex()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "dev,[a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("dev", "Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Does_Not_Match_MultiPart_Name_That_Does_Not_Match_Regex()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "dev,^[0-9][a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("dev", "WOWSES9898989Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Does_Not_Match_MultiPart_Name_That_Does_Not_Match_Lhs_Regex()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "dbo,[0-9][a-zA-Z][a-zA-Z][a-zA-Z]", MatchType.DoesMatch);
+            var objectName = new ObjectIdentifier("dev", "Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Does_Match_MultiPart_Name_That_Does_Not_Match_Regex_But_Is_A_Negative_Match_Type()
+        {
+            var rule = new MultiPartNamedObjectFilterRule(FilterOperation.Ignore, "dev,.*blah.*", MatchType.DoesNotMatch);
+            var objectName = new ObjectIdentifier("dev", "WOWSES9898989Tab");
+
+            var result = rule.Matches(objectName, null);
+
+            Assert.IsTrue(result);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Keep are really only ever used in combination with */p:DropObjectsInSource=True*
 
 Once you know what type of filter you want you need to decide what you will filter on, your choices are: **Name**, **SchemaName** and **object type** (stored procedure, function, table, user, role, rolemembership etc etc).
 
-* Name filters work on an objects name, pretty straight forward.
+* Name filters work on an objects name, pretty straight forward. You can specify a comma-separated set of names to match multipart identifiers. See the examples section for more details. Note that parts are matched from right to left.
 * Schema filters work on the name of the schema so you can keep or ignore everything in a specific schema
 * Object type filters work on the type of the object as the DacFx api sees it, these types are all documented as properties of the ModelSchema class: [link](http://msdn.microsoft.com/en-us/library/microsoft.sqlserver.dac.model.modelschema.aspx)
 
@@ -54,6 +54,17 @@ To keep a table called MyTable or MyExcellentFunnyTable:
 ```
 KeepName(.*yTabl.*)
 ```
+
+Note that this will match the right-most part of a multipart identifier, so this matches, `[dbo].[MyTable]`, `[dbo].[MyExcellentFunnyTable]`,
+`[dev].[MyTable]`, `[dbo].[SomeOtherTable].[MyTabletColumnId]`, etc.
+
+You can match against multiple parts of a multipart identifier, matching from right part to left, by specifying multiple
+values (regex's) separated by a comma:
+```
+KeepName(dbo,.*yTabl.*)
+```
+
+Using the example above, this instead matches only `[dbo].[MyTable]` or `[dbo].[MyExcellentFunnyTable]`.
 
 Behind the scenes, matching relies on regex using the default .Net options for the Match method. 
 To only deploy to the dbo schema (ie exclude non-dbo objects):

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Keep are really only ever used in combination with */p:DropObjectsInSource=True*
 
 Once you know what type of filter you want you need to decide what you will filter on, your choices are: **Name**, **SchemaName** and **object type** (stored procedure, function, table, user, role, rolemembership etc etc).
 
-* Name filters work on an objects name, pretty straight forward. You can specify a comma-separated set of names to match multipart identifiers. See the examples section for more details. Note that parts are matched from right to left.
+* Name filters work on an objects name, pretty straight forward. You can also specify a comma-separated set of names to match multipart identifiers. See the examples section for more details. Note that parts are matched from right to left.
 * Schema filters work on the name of the schema so you can keep or ignore everything in a specific schema
 * Object type filters work on the type of the object as the DacFx api sees it, these types are all documented as properties of the ModelSchema class: [link](http://msdn.microsoft.com/en-us/library/microsoft.sqlserver.dac.model.modelschema.aspx)
 
@@ -55,11 +55,11 @@ To keep a table called MyTable or MyExcellentFunnyTable:
 KeepName(.*yTabl.*)
 ```
 
-Note that this will match the right-most part of a multipart identifier, so this matches, `[dbo].[MyTable]`, `[dbo].[MyExcellentFunnyTable]`,
+Note that this will match the right-most part of a multipart identifier, so this matches: `[dbo].[MyTable]`, `[dbo].[MyExcellentFunnyTable]`,
 `[dev].[MyTable]`, `[dbo].[SomeOtherTable].[MyTabletColumnId]`, etc.
 
 You can match against multiple parts of a multipart identifier, matching from right part to left, by specifying multiple
-values (regex's) separated by a comma:
+values (regexes) separated by a comma:
 ```
 KeepName(dbo,.*yTabl.*)
 ```

--- a/SqlPackageFilter/AgileSqlClub.SqlPackageFilter.csproj
+++ b/SqlPackageFilter/AgileSqlClub.SqlPackageFilter.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Filter\ObjectIdentifierFactory.cs" />
     <Compile Include="Rules\FilterRule.cs" />
     <Compile Include="Filter\FilterType.cs" />
+    <Compile Include="Rules\MultiPartNamedObjectFilterRule.cs" />
     <Compile Include="Rules\NamedObjectFilterRule.cs" />
     <Compile Include="Rules\ObjectTypeFilterRule.cs" />
     <Compile Include="Rules\RuleFactory.cs" />

--- a/SqlPackageFilter/Config/CommandLineFilterParser.cs
+++ b/SqlPackageFilter/Config/CommandLineFilterParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using AgileSqlClub.SqlPackageFilter.Filter;
+using AgileSqlClub.SqlPackageFilter.Rules;
 
 namespace AgileSqlClub.SqlPackageFilter.Config
 {
@@ -39,6 +40,9 @@ namespace AgileSqlClub.SqlPackageFilter.Config
                 case FilterType.TableColumns:
                     remove = 12;
                     break;
+                case FilterType.MultiPartName:
+                    remove = 13;
+                    break;
                 case FilterType.Security:
                 {
                     return new RuleDefinition()
@@ -64,6 +68,12 @@ namespace AgileSqlClub.SqlPackageFilter.Config
             }
             
             var match = value.Trim(new []{'(',')', ' '});
+
+            if (type == FilterType.Name && match.IndexOf(MultiPartNamedObjectFilterRule.Separator) != -1)
+            {
+                // Argument has commas. Assume this is a request to match a multipart name.
+                type = FilterType.MultiPartName;
+            }
             
             var definiton = new RuleDefinition()
             {
@@ -98,6 +108,10 @@ namespace AgileSqlClub.SqlPackageFilter.Config
                 return FilterType.TableColumns;
             }
 
+            if (value.StartsWith("MultiPartName", StringComparison.OrdinalIgnoreCase))
+            {
+                return FilterType.MultiPartName;
+            }
 
             if (value.StartsWith("Security", StringComparison.OrdinalIgnoreCase))
             {

--- a/SqlPackageFilter/Config/RuleDefinitionFactory.cs
+++ b/SqlPackageFilter/Config/RuleDefinitionFactory.cs
@@ -40,6 +40,10 @@ namespace AgileSqlClub.SqlPackageFilter.Config
                         rules.Add(new TableColumnFilterRule(ruleDefinition.Operation, ruleDefinition.Match,
                             ruleDefinition.MatchType));
                         break;
+                    case FilterType.MultiPartName:
+                        rules.Add(new MultiPartNamedObjectFilterRule(ruleDefinition.Operation, ruleDefinition.Match,
+                            ruleDefinition.MatchType));
+                        break;
                 }
             }
 

--- a/SqlPackageFilter/Filter/FilterType.cs
+++ b/SqlPackageFilter/Filter/FilterType.cs
@@ -6,6 +6,7 @@
         Name,
         Type,
         TableColumns,
-        Security    //Pseudo FilterType - All ObjectTypes that are security things
+        Security,    //Pseudo FilterType - All ObjectTypes that are security things
+        MultiPartName,
     }
 }

--- a/SqlPackageFilter/Rules/MultiPartNamedObjectFilterRule.cs
+++ b/SqlPackageFilter/Rules/MultiPartNamedObjectFilterRule.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using AgileSqlClub.SqlPackageFilter.Filter;
+using Microsoft.SqlServer.Dac.Deployment;
+using Microsoft.SqlServer.Dac.Model;
+
+namespace AgileSqlClub.SqlPackageFilter.Rules
+{
+    public class MultiPartNamedObjectFilterRule : FilterRule
+    {
+        internal const char Separator = ',';
+        private readonly Regex[] _matchParts;
+
+        public MultiPartNamedObjectFilterRule(FilterOperation operation, string match, MatchType matchType)
+        // Note that base.Match is unused in this implementation.
+        : base(operation, ".*", matchType)
+        {
+            // This assumes that a literal ',' never appears in a part name.
+            _matchParts = Array.ConvertAll(match.Split(Separator), s => new Regex(s, RegexOptions.Compiled));
+        }
+
+        public override bool Matches(ObjectIdentifier name, ModelTypeClass type, DeploymentStep step = null)
+        {
+            bool matches = true;
+            for (int i = 0; i < name.Parts.Count && i < _matchParts.Length; i++)
+            {
+                // Match names right-to-left, since specificity of a SQL identifier is right-to-left,
+                // and so this behaves identically to NamedObjectFilterRule if the requested match
+                // contains only one argument.
+                var part = name.Parts[name.Parts.Count - 1 - i];
+                var match = _matchParts[_matchParts.Length - 1 - i];
+                if (!match.IsMatch(part))
+                {
+                    matches = false;
+                    break;
+                }
+            }
+            
+            if (matches && MatchType == MatchType.DoesMatch)
+                return true;
+
+            return !matches && MatchType == MatchType.DoesNotMatch;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new MultiPartName filter type, and implicitly extends the Name filter type by letting it support commas.

The (my) use case for this is to be able to specify name filtering rules that match not just the last part of an object name, but multiple parts, from right to left. For example, if I specifically care about a `MyTable` object in the _dbo_ schema, not just any schema:

```
KeepName(dbo,MyTable)
```

The existing KeepName behavior is unchanged; it's just that providing a comma-separated set of values will invoke this new feature being merged here.

Technically, this also behaves identically:

```
KeepMultiPartName(dbo,MyTable)
```

but it seems to me that this separation of filter type is more of an internal thing, and can be done more simply by an end-user via KeepName(). But in any case an end-user can specify the same thing both ways.