### PR TITLE
Fix TableColumnFilterRule (KeepTableColumn filter).

### DIFF
--- a/SqlPackageFilter/Rules/TableColumnFilterRule.cs
+++ b/SqlPackageFilter/Rules/TableColumnFilterRule.cs
@@ -44,7 +44,7 @@ namespace AgileSqlClub.SqlPackageFilter.Rules
             if (script == null)
                 return false;
 
-            var batch = script.Batches.FirstOrDefault();
+            var batch = script.Batches.FirstOrDefault(b => b.Statements.Any(s => s as AlterTableDropTableElementStatement != null));
 
             if (batch == null)
                 return false;
@@ -70,7 +70,7 @@ namespace AgileSqlClub.SqlPackageFilter.Rules
                 return false;
             }  //This is a strange one, we remove the bits we want from the drop table element but there might be other things like constraints that should be dropped
 
-            script.Batches.RemoveAt(0);   
+            script.Batches.Remove(batch);
 
             return script.Batches.Count == 0;
 


### PR DESCRIPTION
There is a bug in TableColumnFilterRule.cs ( SqlPackageFilter=KeepTableColumns(Employees) ). When generated change script starts from PredicateSetStatement (i.e. SET ANSI_NULLS <VALUE> ) instead of AlterTableDropTableElementStatement (as the current code expects), the filter does not remove DROP COLUMN statements. As a result, the columns getting dropped when the expected behavior is that they will remain unmodified.
![TableColumnFilterRule](https://user-images.githubusercontent.com/10056926/78050749-b59d9900-734a-11ea-8114-7644ed9a4711.png)
