### PR TITLE
Fixes #50,  Index was out of range error relating to FullText index

### DIFF
--- a/SqlPackageFilter/DacExtensions/ObjectNameParser.cs
+++ b/SqlPackageFilter/DacExtensions/ObjectNameParser.cs
@@ -38,6 +38,6 @@ namespace AgileSqlClub.SqlPackageFilter.DacExtensions
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        static bool ExpectThreeParts(ModelTypeClass type) => type == ModelSchema.Index || type == ModelSchema.ColumnStoreIndex || type == ModelSchema.FullTextIndex;
+        static bool ExpectThreeParts(ModelTypeClass type) => type == ModelSchema.Index || type == ModelSchema.ColumnStoreIndex;
     }
 }

--- a/SqlPackageFilter/Properties/AssemblyInfo.cs
+++ b/SqlPackageFilter/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.3.0")]
-[assembly: AssemblyFileVersion("1.5.3.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]


### PR DESCRIPTION
Fixes #50 
Remove code that was expecting FullText indexes to be named with three parts, was causing failures when they appeared in databases along with IgnoreSchema filters (and possibly some other filters).
